### PR TITLE
Добавлен migrator.sh, исправления migrator, README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@
 
 ## Установка
 
-1) `composer require arrilot/bitrix-migrations`
+1) `composer require arrilot/bitrix-migrations` из папки bitrix проекта (1С-Битрикс начали поддержиивать сторонние пакеты через composer).
 
-2) `cp vendor/arrilot/bitrix-migrations/migrator migrator` - копируем исполняемый файл в удобное место.
+2) `cp vendor/arrilot/bitrix-migrations/migrator migrator` - копируем исполняемый файл в удобное место или читаем пункт 3.
 
-3) заходим внутрь и удостоверяемся что задается правильный $_SERVER['DOCUMENT_ROOT']. Меняем настройки если нужно
+3) с поставкой идет bash-скрипт `migrator.sh`. Для удобства работы можно, скопировать его в домашний каталог и сделать символическую ссылку в любой каталог с запускаемыми файлами. После этого можно вызывать мигратор командой `migrator` из любого подкаталога проекта.
 
-4) `php migrator install`
+4) заходим внутрь и удостоверяемся что задается правильный $_SERVER['DOCUMENT_ROOT']. Меняем настройки если нужно. Если используется bash-скрипт, настройки рекомендуется менять в нем.
+
+5) `php migrator install` или `migrator install` (здесь и далее, если используется bash-скрипт, вместо команды `php migrator` пишем `migrator`)
 
 Данная команда создаст в БД таблицу для хранения названий выполненных миграций.
 
@@ -157,9 +159,10 @@
 ### Автоматическое создание миграций
 
 Еще одна киллер-фича - режим автоматического создания миграций.
-Для его включения необходимо добавить примерно следующее в `init.php`
+Для его включения необходимо добавить примерно следующее в `init.php` (или в конец `/bitrix/php_interface/after_connect_d7.php`, что более предпочтительно, так как `init.php`, обычно перекрывается файлом `init.php` из папки `/local/php_interface`. А добавлять служебный код в папку `local` не комильфо по целому ряду причин).
 
 ```php
+require_once $_SERVER["DOCUMENT_ROOT"]."/bitrix/vendor/autoload.php";
 Arrilot\BitrixMigrations\Autocreate\Manager::init($_SERVER["DOCUMENT_ROOT"].'/migrations');
 ```
 

--- a/migrator
+++ b/migrator
@@ -14,15 +14,17 @@ use Arrilot\BitrixMigrations\TemplatesCollection;
 use Symfony\Component\Console\Application;
 
 define("NOT_CHECK_PERMISSIONS", true);
-$_SERVER["DOCUMENT_ROOT"] = __DIR__;
+$_SERVER["DOCUMENT_ROOT"] = isset($_SERVER["CLI_DOCUMENT_ROOT"]) ? $_SERVER["CLI_DOCUMENT_ROOT"] : __DIR__;
 $DOCUMENT_ROOT = $_SERVER["DOCUMENT_ROOT"];
+$MIGRATIONS_DIR = isset($_SERVER["MIGRATIONS_DIR"]) ? $_SERVER["MIGRATIONS_DIR"] : $DOCUMENT_ROOT.'/local/migrations';
 require $_SERVER["DOCUMENT_ROOT"]."/bitrix/modules/main/include/prolog_before.php";
+require_once $_SERVER["DOCUMENT_ROOT"]."/bitrix/vendor/autoload.php";
 
 CModule::IncludeModule("iblock");
     
 $config = [
     'table' => 'migrations',
-    'dir' => './migrations',
+    'dir' => $MIGRATIONS_DIR,
     // 'dir_archive' => 'archive', // not required. default = "archive"
 ];
 

--- a/migrator.sh
+++ b/migrator.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+START_DIR=`pwd`
+RUNNING_DIR=$START_DIR
+while [[ $RUNNING_DIR != "/" ]]; do
+    if [ -d "$RUNNING_DIR/bitrix/vendor/arrilot" ]; then
+        break
+    fi
+    RUNNING_DIR="$( dirname "$RUNNING_DIR" )"
+done
+if [[ $RUNNING_DIR == "/" || ! -f "$RUNNING_DIR/bitrix/vendor/arrilot/bitrix-migrations/migrator" ]]; then
+    echo "Probably console run not from Bitrix project root or Arrilot/bitrix-migrations is not installed!";
+    exit
+fi
+SCRIPT="$RUNNING_DIR/bitrix/vendor/arrilot/bitrix-migrations/migrator $*"
+export CLI_DOCUMENT_ROOT="$RUNNING_DIR"
+export MIGRATIONS_DIR="$RUNNING_DIR/local/migrations"
+/usr/bin/env php $SCRIPT


### PR DESCRIPTION
Добавлен migrator.sh
Исправления migrator для запуска из любого каталога.
Изменен README.md

Сценарий применения (для MacOS/Linux):
1. Устанавливаем в bitrix 'composer require arrilot/bitrix-migrations'
2. копируем файл migrator.sh, например в ~/.bin, переименовываем в migrator
3. добавляем в .profile export PATH=~/.bin:$PATH
4. При необходимости правим переменные CLI_DOCUMENT_ROOT и MIGRATIONS_DIR, изначально они настроены:
- CLI_DOCUMENT_ROOT - папка в которой нашелся /bitrix/vendor/arrilot/bitrix-migrations/migrator, т.е. папка проекта
- MIGRATIONS_DIR - папка проекта /local/migrations

Т.о. настроив один раз на системе разработчика migrator, на остальных проектах достаточно выполнить установку мигратора, а далее все будет работать самостоятельно. запуск мигратора можно выполнять из любого каталога проекта одной командой.

миграции лучше хранить в /local,  т.е. они в служебном каталоге, но по git.