### PR TITLE
Фикс возвращаемого кода команды при исключениях

### DIFF
--- a/src/Commands/AbstractCommand.php
+++ b/src/Commands/AbstractCommand.php
@@ -56,9 +56,9 @@ abstract class AbstractCommand extends Command
         } catch (Exception $e) {
             $this->error($e->getMessage());
             $this->error('Abort!');
-        }
 
-        return;
+            return $e->getCode();
+        }
     }
 
     /**

--- a/src/Exceptions/MigrationException.php
+++ b/src/Exceptions/MigrationException.php
@@ -6,4 +6,5 @@ use Exception;
 
 class MigrationException extends Exception
 {
+    protected $code = 255;
 }


### PR DESCRIPTION
Консольные инструменты (CI/CD в частности) не могут отловить момент ошибки, если не возвращать код ошибки.