### PR TITLE
Позволяем задавать кастомные имена командам

### DIFF
--- a/src/Commands/ArchiveCommand.php
+++ b/src/Commands/ArchiveCommand.php
@@ -17,13 +17,14 @@ class ArchiveCommand extends AbstractCommand
     /**
      * Constructor.
      *
-     * @param Migrator $migrator
+     * @param Migrator    $migrator
+     * @param string|null $name
      */
-    public function __construct(Migrator $migrator)
+    public function __construct(Migrator $migrator, $name = null)
     {
         $this->migrator = $migrator;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**

--- a/src/Commands/ArchiveCommand.php
+++ b/src/Commands/ArchiveCommand.php
@@ -13,6 +13,7 @@ class ArchiveCommand extends AbstractCommand
      * @var Migrator
      */
     protected $migrator;
+    protected static $defaultName = 'archive';
 
     /**
      * Constructor.
@@ -32,8 +33,7 @@ class ArchiveCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('archive')
-            ->setDescription('Move migration into archive')
+        $this->setDescription('Move migration into archive')
             ->addOption('without', 'w', InputOption::VALUE_REQUIRED, 'Archive without last N migration');
     }
 

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -25,13 +25,14 @@ class InstallCommand extends AbstractCommand
      *
      * @param string                   $table
      * @param DatabaseStorageInterface $database
+     * @param string|null              $name
      */
-    public function __construct($table, DatabaseStorageInterface $database)
+    public function __construct($table, DatabaseStorageInterface $database, $name = null)
     {
         $this->table = $table;
         $this->database = $database;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -20,6 +20,8 @@ class InstallCommand extends AbstractCommand
      */
     protected $table;
 
+    protected static $defaultName = 'install';
+
     /**
      * Constructor.
      *
@@ -40,7 +42,7 @@ class InstallCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('install')->setDescription('Create the migration database table');
+        $this->setDescription('Create the migration database table');
     }
 
     /**

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -15,6 +15,8 @@ class MakeCommand extends AbstractCommand
      */
     protected $migrator;
 
+    protected static $defaultName = 'make';
+
     /**
      * Constructor.
      *
@@ -33,8 +35,7 @@ class MakeCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('make')
-            ->setDescription('Create a new migration file')
+        $this->setDescription('Create a new migration file')
             ->addArgument(
                 'name',
                 InputArgument::REQUIRED,

--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -18,13 +18,14 @@ class MakeCommand extends AbstractCommand
     /**
      * Constructor.
      *
-     * @param Migrator $migrator
+     * @param Migrator    $migrator
+     * @param string|null $name
      */
-    public function __construct(Migrator $migrator)
+    public function __construct(Migrator $migrator, $name = null)
     {
         $this->migrator = $migrator;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -13,6 +13,7 @@ class MigrateCommand extends AbstractCommand
      */
     protected $migrator;
 
+    protected static $defaultName = 'migrate';
     /**
      * Constructor.
      *
@@ -31,7 +32,7 @@ class MigrateCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('migrate')->setDescription('Run all outstanding migrations');
+        $this->setDescription('Run all outstanding migrations');
     }
 
     /**

--- a/src/Commands/MigrateCommand.php
+++ b/src/Commands/MigrateCommand.php
@@ -16,13 +16,14 @@ class MigrateCommand extends AbstractCommand
     /**
      * Constructor.
      *
-     * @param Migrator $migrator
+     * @param Migrator    $migrator
+     * @param string|null $name
      */
-    public function __construct(Migrator $migrator)
+    public function __construct(Migrator $migrator, $name = null)
     {
         $this->migrator = $migrator;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -18,13 +18,14 @@ class RollbackCommand extends AbstractCommand
     /**
      * Constructor.
      *
-     * @param Migrator $migrator
+     * @param Migrator    $migrator
+     * @param string|null $name
      */
-    public function __construct(Migrator $migrator)
+    public function __construct(Migrator $migrator, $name = null)
     {
         $this->migrator = $migrator;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -15,6 +15,8 @@ class RollbackCommand extends AbstractCommand
      */
     protected $migrator;
 
+    protected static $defaultName = 'rollback';
+
     /**
      * Constructor.
      *
@@ -33,8 +35,7 @@ class RollbackCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('rollback')
-            ->setDescription('Rollback the last migration')
+        $this->setDescription('Rollback the last migration')
             ->addOption('hard', null, InputOption::VALUE_NONE, 'Rollback without running down()')
             ->addOption('delete', null, InputOption::VALUE_NONE, 'Delete migration file after rolling back');
     }

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -13,6 +13,8 @@ class StatusCommand extends AbstractCommand
      */
     protected $migrator;
 
+    protected static $defaultName = 'status';
+
     /**
      * Constructor.
      *
@@ -31,7 +33,7 @@ class StatusCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('status')->setDescription('Show status about last migrations');
+        $this->setDescription('Show status about last migrations');
     }
 
     /**

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -16,13 +16,14 @@ class StatusCommand extends AbstractCommand
     /**
      * Constructor.
      *
-     * @param Migrator $migrator
+     * @param Migrator    $migrator
+     * @param string|null $name
      */
-    public function __construct(Migrator $migrator)
+    public function __construct(Migrator $migrator, $name = null)
     {
         $this->migrator = $migrator;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**

--- a/src/Commands/TemplatesCommand.php
+++ b/src/Commands/TemplatesCommand.php
@@ -15,6 +15,8 @@ class TemplatesCommand extends AbstractCommand
      */
     protected $collection;
 
+    protected static $defaultName = 'templates';
+
     /**
      * Constructor.
      *
@@ -33,7 +35,7 @@ class TemplatesCommand extends AbstractCommand
      */
     protected function configure()
     {
-        $this->setName('templates')->setDescription('Show the list of available migration templates');
+        $this->setDescription('Show the list of available migration templates');
     }
 
     /**

--- a/src/Commands/TemplatesCommand.php
+++ b/src/Commands/TemplatesCommand.php
@@ -19,12 +19,13 @@ class TemplatesCommand extends AbstractCommand
      * Constructor.
      *
      * @param TemplatesCollection $collection
+     * @param string|null         $name
      */
-    public function __construct(TemplatesCollection $collection)
+    public function __construct(TemplatesCollection $collection, $name = null)
     {
         $this->collection = $collection;
 
-        parent::__construct();
+        parent::__construct($name);
     }
 
     /**


### PR DESCRIPTION
Эти команды могут быть не единственными в проекте, и в этом случае командам имеет смысл задать неймспейс. В моем случае их выполнение выглядит как `php app migrator:migrate`.