### PR TITLE
Упрощаем InstallCommand

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -26,9 +26,9 @@ class InstallCommand extends AbstractCommand
      * @param string                   $table
      * @param DatabaseStorageInterface $database
      */
-    public function __construct($table, DatabaseStorageInterface $database)
+    public function __construct(DatabaseStorageInterface $database)
     {
-        $this->table = $table;
+        $this->table = $database->getTableName();
         $this->database = $database;
 
         parent::__construct();

--- a/src/Interfaces/DatabaseStorageInterface.php
+++ b/src/Interfaces/DatabaseStorageInterface.php
@@ -5,6 +5,12 @@ namespace Arrilot\BitrixMigrations\Interfaces;
 interface DatabaseStorageInterface
 {
     /**
+     * Returns a DB table name if it was set
+     * @return string|null
+     */
+    public function getTableName();
+
+    /**
      * Check if a given table already exists.
      *
      * @return bool

--- a/src/Storages/BitrixDatabaseStorage.php
+++ b/src/Storages/BitrixDatabaseStorage.php
@@ -122,4 +122,12 @@ class BitrixDatabaseStorage implements DatabaseStorageInterface
     {
         $this->db->Rollback();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTableName()
+    {
+        return $this->table;
+    }
 }

--- a/tests/InstallCommandTest.php
+++ b/tests/InstallCommandTest.php
@@ -8,7 +8,7 @@ class InstallCommandTest extends CommandTestCase
 {
     protected function mockCommand($database)
     {
-        return m::mock('Arrilot\BitrixMigrations\Commands\InstallCommand[abort]', ['migrations', $database])
+        return m::mock('Arrilot\BitrixMigrations\Commands\InstallCommand[abort]', [$database])
             ->shouldAllowMockingProtectedMethods();
     }
 
@@ -16,6 +16,7 @@ class InstallCommandTest extends CommandTestCase
     {
         $database = m::mock('Arrilot\BitrixMigrations\Interfaces\DatabaseStorageInterface');
         $database->shouldReceive('checkMigrationTableExistence')->once()->andReturn(false);
+        $database->shouldReceive('getTableName')->once()->andReturn('migrations');
         $database->shouldReceive('createMigrationTable')->once();
 
         $command = $this->mockCommand($database);
@@ -27,6 +28,7 @@ class InstallCommandTest extends CommandTestCase
     {
         $database = m::mock('Arrilot\BitrixMigrations\Interfaces\DatabaseStorageInterface');
         $database->shouldReceive('checkMigrationTableExistence')->once()->andReturn(true);
+        $database->shouldReceive('getTableName')->once()->andReturn('migrations');
         $database->shouldReceive('createMigrationTable')->never();
 
         $command = $this->mockCommand($database);


### PR DESCRIPTION
В команду install можно не передавать название таблицы, которое и без того задается в BitrixDatabaseStorage